### PR TITLE
Do not link with ${PERL_LIBRARIES}

### DIFF
--- a/bindings_perl/CMakeLists.txt
+++ b/bindings_perl/CMakeLists.txt
@@ -42,4 +42,4 @@ swig_add_library(
 set_target_properties(${PERL_BINDING_TARGET_NAME}
                       PROPERTIES OUTPUT_NAME sourcetraildb)
 
-swig_link_libraries(${PERL_BINDING_TARGET_NAME} ${PERL_LIBRARIES} ${LIB_CORE_TARGET_NAME})
+swig_link_libraries(${PERL_BINDING_TARGET_NAME} ${LIB_CORE_TARGET_NAME})


### PR DESCRIPTION
When compiling with a Perl that uses an archive `.a` for libperl (such as those built with `perlbrew`):

```
$ perlbrew exec --with perl-5.26.1 perl -V:libperl
libperl='libperl.a';

$ /usr/bin/perl -V:libperl
libperl='libperl.so.5.28';
```

I get the following error on linking:

```
Scanning dependencies of target bindings_perl_swig_compilation
[ 70%] Swig compile ~/.../SourcetrailDB/bindings_perl/../resources_swig/interface/sourcetraildb.i for perl
[ 70%] Built target bindings_perl_swig_compilation
Scanning dependencies of target bindings_perl
[ 75%] Building CXX object bindings_perl/CMakeFiles/bindings_perl.dir/src/sourcetraildbPERL_wrap.cxx.o
[ 79%] Building CXX object bindings_perl/CMakeFiles/bindings_perl.dir/__/resources_swig/src/sourcetraildb.cpp.o
[ 83%] Linking CXX shared library sourcetraildb.so
/usr/bin/ld: ~/perl5/perlbrew/perls/perl-5.26.1/lib/5.26.1/x86_64-linux/CORE/libperl.a(op.o): relocation R_X86_64_PC32 against symbol `PL_compcv' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: final link failed: bad value
collect2: error: ld returned 1 exit status
```

If I remove the explicit linking with `libperl`, then the build works with both `.a` and `.so` `libperl`s.